### PR TITLE
Add proper empty state for stream table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled, { ThemeProvider } from "styled-components";
 
 import { Button, Title } from "@gnosis.pm/safe-react-components";
@@ -31,13 +31,14 @@ const StyledBackButton = styled(Button).attrs({
 
 function SablierWidget() {
   /** State Variables **/
-  const [appsSdk, safeInfo]: [SdkInstance, SafeInfo | undefined] = useAppsSdk();
-  const [shouldDisplayStreams, setShouldDisplayStreams] = useState<boolean>(false);
-  const [outgoingProxyStreams, setOutgoingProxyStreams] = useState<ProxyStream[]>([]);
 
-  const toggleShouldDisplayStreams = () => {
+  const [appsSdk, safeInfo]: [SdkInstance, SafeInfo | undefined] = useAppsSdk();
+  const [outgoingProxyStreams, setOutgoingProxyStreams] = useState<ProxyStream[]>([]);
+  const [shouldDisplayStreams, setShouldDisplayStreams] = useState<boolean>(false);
+
+  const toggleShouldDisplayStreams = useCallback(() => {
     setShouldDisplayStreams((prevShouldDisplayStreams: boolean) => !prevShouldDisplayStreams);
-  };
+  }, [setShouldDisplayStreams]);
 
   /** Side Effects **/
 
@@ -52,7 +53,7 @@ function SablierWidget() {
     };
 
     loadOutgoingStreams();
-  }, [safeInfo]);
+  }, [safeInfo, setOutgoingProxyStreams]);
 
   return (
     <ThemeProvider theme={theme}>
@@ -68,7 +69,7 @@ function SablierWidget() {
         )}
 
         {shouldDisplayStreams ? (
-          <StreamTable appsSdk={appsSdk} safeInfo={safeInfo} outgoingProxyStreams={outgoingProxyStreams} />
+          <StreamTable appsSdk={appsSdk} outgoingProxyStreams={outgoingProxyStreams} safeInfo={safeInfo} />
         ) : (
           <CreateStreamForm appsSdk={appsSdk} safeInfo={safeInfo} />
         )}

--- a/src/components/CreateStreamForm/index.tsx
+++ b/src/components/CreateStreamForm/index.tsx
@@ -20,10 +20,9 @@ import { getTokenList, TokenItem } from "../../config/tokens";
 export type Props = {
   appsSdk: SdkInstance;
   safeInfo?: SafeInfo;
-  toggleShouldDisplayStreams: Function;
 };
 
-function CreateStreamForm({ appsSdk, safeInfo, toggleShouldDisplayStreams }: Props) {
+function CreateStreamForm({ appsSdk, safeInfo }: Props) {
   /** State Variables **/
 
   const [amountError, setAmountError] = useState<string | undefined>();
@@ -233,9 +232,6 @@ function CreateStreamForm({ appsSdk, safeInfo, toggleShouldDisplayStreams }: Pro
       <ButtonContainer>
         <Button size="lg" color="primary" variant="contained" onClick={createStream} disabled={isButtonDisabled()}>
           Create Stream
-        </Button>
-        <Button size="lg" color="secondary" variant="contained" onClick={() => toggleShouldDisplayStreams()}>
-          Manage Existing Streams
         </Button>
       </ButtonContainer>
     </>

--- a/src/components/StreamTable/index.tsx
+++ b/src/components/StreamTable/index.tsx
@@ -122,6 +122,7 @@ function StreamTable({ appsSdk, safeInfo }: { appsSdk: SdkInstance; safeInfo?: S
       defaultRowsPerPage={10}
       label="Transactions"
       size={tableContents.length}
+      disableLoadingOnEmptyTable
     >
       {(sortedData: TableRowData[]) =>
         sortedData.map((row: TableRowData) => (

--- a/src/components/StreamTable/index.tsx
+++ b/src/components/StreamTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useMemo, useState, useCallback } from "react";
+import React, { ReactElement, useMemo, useCallback } from "react";
 import { Button } from "@gnosis.pm/safe-react-components";
 import { SafeInfo, SdkInstance } from "@gnosis.pm/safe-apps-sdk";
 import moment from "moment";
@@ -9,7 +9,6 @@ import TableRow from "@material-ui/core/TableRow";
 import Table from "./Table";
 import Status, { StreamStatus } from "./Status";
 import cancelStreamTxs from "../../utils/transactions/cancelStream";
-import getProxyStreams from "../../gql/proxyStreams";
 
 import { ProxyStream, Token } from "../../typings";
 import { BigNumberToRoundedHumanFormat } from "../../utils/format";
@@ -65,11 +64,15 @@ const humanReadableStream = (stream: ProxyStream): HumanReadableStream => {
   };
 };
 
-function StreamTable({ appsSdk, safeInfo }: { appsSdk: SdkInstance; safeInfo?: SafeInfo }): ReactElement {
-  /** State Variables **/
-
-  const [outgoingProxyStreams, setOutgoingProxyStreams] = useState<ProxyStream[]>([]);
-
+function StreamTable({
+  appsSdk,
+  safeInfo,
+  outgoingProxyStreams,
+}: {
+  appsSdk: SdkInstance;
+  safeInfo?: SafeInfo;
+  outgoingProxyStreams: ProxyStream[];
+}): ReactElement {
   /** Memoized Variables **/
 
   const columns = useMemo(() => {
@@ -90,21 +93,6 @@ function StreamTable({ appsSdk, safeInfo }: { appsSdk: SdkInstance; safeInfo?: S
     },
     [appsSdk, safeInfo],
   );
-
-  /** Side Effects **/
-
-  useEffect(() => {
-    const loadOutgoingStreams = async () => {
-      if (!safeInfo || !safeInfo.network || !safeInfo.safeAddress) {
-        return;
-      }
-
-      const proxyStreams: ProxyStream[] = await getProxyStreams(safeInfo.network, safeInfo.safeAddress);
-      setOutgoingProxyStreams(proxyStreams);
-    };
-
-    loadOutgoingStreams();
-  }, [safeInfo]);
 
   const tableContents: TableRowData[] = outgoingProxyStreams.map(proxyStream => ({
     ...humanReadableStream(proxyStream),


### PR DESCRIPTION
I've prevented the infinite loading behaviour on `StreamTable` through the `disableLoadingOnEmptyTable` prop.

I've also taken the opportunity to load the outgoing streams on `App` so that a new request isn't made on each visit to the table page. This has had a noticeable effect on load times.

The "Manage Existing Streams" button has also been moved to near the title like the "Back" button. This doesn't look particularly great but both of these buttons can be restyled together to solve #44 

The current appearance is as so:

![Screenshot_2020-06-10_21-43-24](https://user-images.githubusercontent.com/15848336/84316689-761dd500-ab63-11ea-81fa-c5ba3e9fc60b.png)

fixes #47 