### PR TITLE
Fix stream balance display for cancelled streams

### DIFF
--- a/src/components/CreateStreamForm/index.tsx
+++ b/src/components/CreateStreamForm/index.tsx
@@ -16,7 +16,7 @@ import createStreamTxs from "../../utils/transactions/createStream";
 import { ButtonContainer, SelectContainer } from "../index";
 import { TokenItem, getTokenList } from "../../config/tokens";
 import { Transaction } from "../../typings";
-import { bigNumberToHumanFormat } from "../../utils";
+import { bigNumberToHumanFormat, SECONDS_IN_HOUR } from "../../utils";
 
 const Wrapper = styled.div`
   display: flex;
@@ -74,7 +74,7 @@ function CreateStreamForm({ appsSdk, safeInfo }: Props) {
     /* TODO: Stream initiation must be approved by other owners within an hour */
     const totalSeconds: number = duration.totalSeconds.toNumber();
     const currentUnix: number = Math.floor(new Date().getTime() / 1000);
-    const startTime: BigNumber = BigNumber.from(currentUnix).add(3600);
+    const startTime: BigNumber = BigNumber.from(currentUnix).add(SECONDS_IN_HOUR);
     const stopTime: BigNumber = startTime.add(totalSeconds);
 
     const bnStreamAmount = BigNumber.from(streamAmount);

--- a/src/gql/proxyStreams.ts
+++ b/src/gql/proxyStreams.ts
@@ -18,6 +18,7 @@ const streamQuery: string = `
     cancellation {
       id
       txhash
+      timestamp
     }
     deposit
     startTime


### PR DESCRIPTION
Previously the `StreamInfo` component would incorrectly continue showing funds being streamed from the user to the stream recipient. This PR locks this display to stop at the values at which the stream was cancelled.